### PR TITLE
chore: disable mac in ci b/c it's flaky

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           - 14
         os:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
           # - windows-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The tests keep failing sporadically on Mac with error messages like:

```
✖ Timed out while running tests

2 tests were pending in test/collision.js

◌ collision › cruid collision resistance
◌ collision › cruid.slug collision resistance
```

Here's a screenshot:
<img width="612" alt="Screen Shot 2022-07-25 at 5 06 10 PM" src="https://user-images.githubusercontent.com/1929625/180874203-d127cfe6-a958-4977-bd58-604844042948.png">

Doesn't _always_ fail, and I tried working around the problem with `--serial` (based on suggestions from ava issues), but this is too much of a hassle. The failures are always false negatives.

So, for the time being, we'll just test on Linux/Ubuntu.